### PR TITLE
Add activity feed API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Added a new Express server with a mock activity feed endpoint.

### What changed?

- Created a new `server.js` file in the `graphite-demo` directory.
- Implemented an Express server that listens on port 3000.
- Added a `/feed` endpoint that returns a mock activity feed as JSON.
- Included sample activity feed data with three entries.

### How to test?

1. Install dependencies: `npm install express`
2. Start the server: `node server.js`
3. Send a GET request to `http://localhost:3000/feed`
4. Verify that the response contains the mock activity feed data in JSON format.

### Why make this change?

This change sets up a basic backend infrastructure for the Graphite demo project. It provides a simple API endpoint that can be used to fetch activity feed data, which will be useful for frontend development and testing. The mock data allows for immediate testing and integration without the need for a full database setup at this stage.